### PR TITLE
Add to_s to make token eval more transparent

### DIFF
--- a/lib/voicebase/client/token.rb
+++ b/lib/voicebase/client/token.rb
@@ -12,5 +12,9 @@ module VoiceBase
     def expired?
       Time.now > created_at + (timeout / 1000.to_f)
     end
+
+    def to_s
+      @token
+    end
   end
 end

--- a/lib/voicebase/v2/client.rb
+++ b/lib/voicebase/v2/client.rb
@@ -22,6 +22,7 @@ module VoiceBase
           ), api_version)
         @token = VoiceBase::Client::Token.new(response.tokens.any? && response.tokens.first.fetch("token"))
       rescue NoMethodError => ex
+        byebug
         raise VoiceBase::AuthenticationError, response.status_message
       end
 
@@ -148,8 +149,9 @@ module VoiceBase
       def default_headers(headers = {})
         authenticate! unless token
         headers = {
-            'Authorization' => "Bearer #{token.token}",
-            'User-Agent' => user_agent
+          'User-Agent' => user_agent,
+        }.tap {|o|
+          o['Authorization'] = "Bearer #{token}" if token
         }.reject { |k, v| blank?(v) }.merge(headers)
         puts "> headers\n> #{headers}" if debug
         headers

--- a/lib/voicebase/v2/response.rb
+++ b/lib/voicebase/v2/response.rb
@@ -26,15 +26,15 @@ module VoiceBase
         # the plain text transcript is a plain text non-JSON response
         voicebase_response['media']['transcripts']['latest']['words']
       end
-      
+
       def keywords
         voicebase_response['media']['keywords']['latest']['words']
       end
-      
+
       def keyword_groups
         voicebase_response['media']['keywords']['latest']['groups']
       end
-      
+
       def topics
         voicebase_response['media']['topics']['latest']['topics']
       end

--- a/spec/lib/voicebase/client/token_spec.rb
+++ b/spec/lib/voicebase/client/token_spec.rb
@@ -24,5 +24,9 @@ describe VoiceBase::Client::Token do
       Timecop.travel(expired_time)
       expect(token.expired?).to be_truthy
     end
+
+    it "delegates token method to_s" do
+      expect(VoiceBase::Client::Token.new("foobar").to_s).to eq("foobar")
+    end
   end
 end

--- a/spec/lib/voicebase/v1/client_spec.rb
+++ b/spec/lib/voicebase/v1/client_spec.rb
@@ -30,6 +30,14 @@ describe VoiceBase::V1::Client do
   end
 
   describe VoiceBase::Client::Token do
+    let(:timeout) { 10 }
+    let(:initial_time) { Time.local(2016, 5, 2, 16, 22, 0) }
+    let(:expired_time) { Time.local(2016, 5, 2, 16, 22, timeout + 1) }
+
+    before do
+      Timecop.freeze(initial_time)
+    end
+
     it "should create token instance" do
       token = VoiceBase::Client::Token.new("abcd-token", 1440)
       expect(token.token).to eq("abcd-token")
@@ -43,8 +51,8 @@ describe VoiceBase::V1::Client do
     end
 
     it "should be expired?" do
-      token = VoiceBase::Client::Token.new("expired-token", 0)
-      sleep 0.2
+      token = VoiceBase::Client::Token.new("expired-token", timeout)
+      Timecop.travel(expired_time)
       expect(token.expired?).to eq(true)
     end
   end

--- a/spec/lib/voicebase/v2/client_spec.rb
+++ b/spec/lib/voicebase/v2/client_spec.rb
@@ -20,7 +20,7 @@ describe VoiceBase::V2::Client do
   let(:auth_token) { "My-Auth-Token" }
 
   before do
-    client.token = double("voicebase token", token: auth_token)
+    client.token = double("voicebase token", token: auth_token, to_s: auth_token)
   end
 
   context "pre-authentication" do


### PR DESCRIPTION
  * use timecop for token expiry testing
  * add to_s for token
  * remove trailing spaces